### PR TITLE
Upgrade to grafana 7.5.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM socrata/runit-focal
 
-ENV GRAFANA_VERSION 7.5.15
+ENV GRAFANA_VERSION 7.5.17
 
 RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \
     apt-get -y install libfontconfig wget adduser openssl ca-certificates && \


### PR DESCRIPTION
Upgrade to grafana 7.5.17, the latest 7.5.x branch available from grafana.com/grafana/download