### PR TITLE
skip attempting script to poplulate env vars in ecs

### DIFF
--- a/sv/grafana-run
+++ b/sv/grafana-run
@@ -3,7 +3,9 @@
 # grafana-db-pw.sh must have lines like the following:
 #   export GF_DATABASE_USER=abc
 #   export GF_DATABASE_PASSWORD=def123
-. /dev/shm/grafana-db-pw.sh
+if [ "$AWS_EXECUTION_ENV" != "AWS_ECS_FARGATE" ];then
+  . /dev/shm/grafana-db-pw.sh
+fi
 
 CMD="/usr/sbin/grafana-server \
   --homepath=/usr/share/grafana \


### PR DESCRIPTION
fails to start up in ecs.  skip sourcing the env secrets file in that runtime.