### PR TITLE
Migrating from mesos to ecs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ commonPipeline(
     [
       name: 'grafana',
       type: 'service',
-      deploymentEcosystem: 'marathon-mesos',
+      deploymentEcosystem: 'ecs',
       paths: [
         dockerBuildContext: '.'
       ],


### PR DESCRIPTION
I'm probably 1 or 2 days away from completing the rollout or Grafana to ECS. Let's set its deployment to `ecs` in time for the next release.