### PR TITLE
Fix commonPipeline format for v10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,6 @@
 
 commonPipeline(
   jobName: 'grafana',
-  language: 'bash',
   projects: [
     [
       name: 'grafana',
@@ -11,6 +10,7 @@ commonPipeline(
       docker: [
         buildContext: '.'
       ],
+      language: 'bash',
     ],
   ],
   teamsChannelWebhookId: 'WORKFLOW_TIRE_Q_AND_A',


### PR DESCRIPTION
This commit fixes the commonPipeline format for the socrata-pipeline-library version 10.